### PR TITLE
fix(footer): fix double footer in other pages

### DIFF
--- a/src/components/Page.tsx
+++ b/src/components/Page.tsx
@@ -42,7 +42,7 @@ export const Page: React.FC<PageProps> = ({
       </Head>
       <header
         className={cx(
-          "pt-0 mt-0 mb-4 border-b",
+          "pt-8 mt-8 mb-8 border-b",
           "border-gray-200",
           "dark:border-gray-700"
         )}
@@ -67,7 +67,7 @@ export const Page: React.FC<PageProps> = ({
           </div>
         ) : null}
       </header>
-      <div className="max-w-3xl px-4">
+      <div className="max-w-3xl px-4 mb-8">
         {" "}
         {/* Hilangkan mx-auto untuk menempel ke atas */}
         {children}

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,9 +1,7 @@
 import "@/styles/globals.css";
 import "@/styles/partials/_footer.scss";
-
 import { ThemeProvider } from "next-themes";
 import type { AppProps } from "next/app";
-import Footer from "../components/ui/footer"; // Pastikan untuk mengganti sesuai path yang benar
 import { NavigationMenu } from "@/components/ui/navigation-menu";
 
 function MyApp({ Component, pageProps }: AppProps) {
@@ -24,7 +22,6 @@ function MyApp({ Component, pageProps }: AppProps) {
         <main id="main">
           <Component {...pageProps} />
         </main>
-        <Footer />
       </div>
     </ThemeProvider>
   );

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -7,6 +7,7 @@ import { PostList } from "@/components/PostList";
 import { ArrowRight } from "react-feather";
 import { NavigationMenuDemo } from "@/components/ui/navbar";
 import CarouselPlugin from "@/components/carousel";
+import Footer from "@/components/ui/footer";
 
 interface HomeProps {
   posts: Array<MDXFrontMatter>;
@@ -44,6 +45,7 @@ const Home: NextPage<HomeProps> = ({ posts }) => {
             </Link>
           </div>
         </Page>
+        <Footer />
       </div>
     </>
   );

--- a/src/pages/posts/index.tsx
+++ b/src/pages/posts/index.tsx
@@ -4,6 +4,7 @@ import { MDXFrontMatter } from "../../../lib/types";
 import { Page } from "@/components/Page";
 import { PostList } from "@/components/PostList";
 import { NavigationMenuDemo } from "@/components/ui/navbar";
+import Footer from "@/components/ui/footer";
 
 interface PostsProps {
   posts: Array<MDXFrontMatter>;
@@ -17,6 +18,7 @@ const Posts: NextPage<PostsProps> = ({ posts }) => {
         <Page title="Posts" description="Blog post tentang Ryo">
           <PostList posts={posts} />
         </Page>
+        <Footer />
       </div>
     </>
   );


### PR DESCRIPTION
fix pages:
import "@/styles/globals.css";
import "@/styles/partials/_footer.scss";
import { ThemeProvider } from "next-themes";
import type { AppProps } from "next/app";
import { NavigationMenu } from "@/components/ui/navigation-menu";

function MyApp({ Component, pageProps }: AppProps) {
  return (
    <ThemeProvider
      disableTransitionOnChange
      defaultTheme="system"
      attribute="class"
    >
      <a
        href="#main"
        className="fixed p-2 top-0 left-0 -translate-y-full focus:translate-y-0"
      >
        Skip to main content
      </a>
      <div className="flex flex-col max-w-3xl mx-auto min-h-full px-4">
        <NavigationMenu />
        <main id="main">
          <Component {...pageProps} />
        </main>
      </div>
    </ThemeProvider>
  );
}

export default MyApp;


delete footer from _app.tsx (bug)